### PR TITLE
Fix Docker build: correct entrypoint perms and enforce LF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+TZ=America/New_York
+SERVER_NAME=Simple Valheim Server
+WORLD_NAME=Dedicated
+SERVER_PASS=changeme
+SERVER_PUBLIC=1
+SERVER_PORT=2456
+ADMIN_LIST=
+SERVER_ARGS=

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: build-and-publish
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+server-data/
+.env
+.docker/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN dpkg --add-architecture i386 \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+       ca-certificates curl lib32gcc-s1 lib32stdc++6 procps tar xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/steamcmd \
+  && curl -sL https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz \
+     | tar -C /opt/steamcmd -xz
+
+# Create server dir and non-root user
+RUN useradd -m -s /bin/bash steam && mkdir -p /server && chown -R steam:steam /server /opt/steamcmd
+
+# Copy entrypoint as root, set perms, normalize line endings
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && chown steam:steam /entrypoint.sh && sed -i 's/\r$//' /entrypoint.sh
+
+# Now switch to steam and install the server
+USER steam
+WORKDIR /server
+
+# Build-time install of Valheim dedicated server (AppID 896660)
+RUN /opt/steamcmd/steamcmd.sh +login anonymous \
+    +force_install_dir /server \
+    +app_update 896660 validate \
+    +quit
+
+ENV SERVER_NAME="Simple Valheim Server" \
+    WORLD_NAME="Dedicated" \
+    SERVER_PASS="changeme" \
+    SERVER_PUBLIC=1 \
+    SERVER_PORT=2456 \
+    SERVER_ARGS="" \
+    ADMIN_LIST="" \
+    TZ=UTC
+
+EXPOSE 2456/udp 2457/udp 2458/udp
+
+VOLUME ["/server"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 chubbs1900
+Copyright (c) 2025 …
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# simple-valheim-server-container
-A simple container for valheim dedicated server
+# Simple Valheim Server Container 🛡️🌲
+
+Launch a **Valheim dedicated server** in Docker with a **single folder** for backups and **drag-and-drop mod support** (BepInEx/r2modman).  
+Target game build: **0.220.5**. This image **does not auto-update** at runtime; update by rebuilding when your mods are ready.
+
+## Features
+- One volume (`/server`) holds binaries, saves, logs, configs, and (optionally) BepInEx/mods
+- Portainer-friendly `docker-compose.yml`
+- Env-var configuration; `SERVER_ARGS` for advanced flags/world modifiers
+- Cross-platform (Windows/macOS/Linux with Docker)
+
+## Quick Start (Portainer)
+Use this compose in a Portainer stack (adjust paths/vars):
+
+```yaml
+version: "3.8"
+services:
+  valheim:
+    image: ghcr.io/REPLACE_ME/simple-valheim-server-container:latest
+    container_name: valheim_server
+    environment:
+      - TZ=America/New_York
+      - SERVER_NAME=My Valheim Server
+      - WORLD_NAME=Dedicated
+      - SERVER_PASS=changeme
+      - SERVER_PUBLIC=1
+      - SERVER_PORT=2456
+      - ADMIN_LIST=
+      - SERVER_ARGS=
+    volumes:
+      - "C:/Valheim Server:/server"  # Windows example
+    ports:
+      - "2456:2456/udp"
+      - "2457:2457/udp"
+      - "2458:2458/udp"
+    restart: unless-stopped
+```
+
+Shell scripts use LF endings; Windows contributors should avoid CRLF for `.sh` files (enforced via `.gitattributes`).
+
+Mods (BepInEx / r2modman)
+
+Export/copy your r2modman profile contents into the host folder you mapped to /server.
+Place BepInEx files next to valheim_server.x86_64 within that folder. No extra steps are needed.
+
+Configuration
+Env VarDefaultNotes
+SERVER_NAMESimple Valheim ServerName in server browser
+WORLD_NAMEDedicatedSave name
+SERVER_PASSchangeme5–10 chars
+SERVER_PUBLIC11=public, 0=private
+SERVER_PORT2456UDP 2456–2458 are exposed
+ADMIN_LIST(blank)Steam64 IDs separated by commas/spaces/newlines
+SERVER_ARGS(blank)Advanced flags/world modifiers (e.g., -crossplay -saveinterval 600)
+TZUTCContainer timezone
+Update Policy
+
+This image pulls the Valheim server at build time. To update the game version, rebuild the image and redeploy.
+
+Local Dev
+docker build -t simple-valheim .
+docker run -d --name valheim \
+  -p 2456:2456/udp -p 2457:2457/udp -p 2458:2458/udp \
+  -e SERVER_NAME="My Valheim" \
+  -e WORLD_NAME="Dedicated" \
+  -e SERVER_PASS="changeme" \
+  -v "$PWD/server-data:/server" \
+  simple-valheim
+
+License
+
+MIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+services:
+  valheim:
+    # For local testing build from source; for Portainer users use GHCR image (see README).
+    build: .
+    container_name: valheim_server
+    environment:
+      - TZ=America/New_York
+      - SERVER_NAME=Eldradia Reborn
+      - WORLD_NAME=EldradiaWorld
+      - SERVER_PASS=xdxdx
+      - SERVER_PUBLIC=1
+      - SERVER_PORT=2456
+      - ADMIN_LIST=
+      - SERVER_ARGS=
+    volumes:
+      # Change this for Portainer/Windows to a real path, e.g.:
+      # - "C:/Valheim Server:/server"
+      - ./server-data:/server
+    ports:
+      - "2456:2456/udp"
+      - "2457:2457/udp"
+      - "2458:2458/udp"
+    restart: unless-stopped

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Write adminlist.txt if ADMIN_LIST provided (comma/space/newline separated)
+if [[ -n "${ADMIN_LIST:-}" ]]; then
+  echo "Writing adminlist.txt from ADMIN_LIST"
+  echo -e "$(echo "$ADMIN_LIST" | tr ', ' '\n\n' | sed '/^\s*$/d')" > /server/adminlist.txt
+fi
+
+cd /server
+
+# Launch server; extra flags via SERVER_ARGS (e.g., -crossplay, -saveinterval 600)
+exec /server/valheim_server.x86_64 \
+  -name     "${SERVER_NAME}" \
+  -world    "${WORLD_NAME}" \
+  -password "${SERVER_PASS}" \
+  -port     "${SERVER_PORT}" \
+  -public   "${SERVER_PUBLIC}" \
+  ${SERVER_ARGS}


### PR DESCRIPTION
## Summary
- fix Dockerfile to copy and chmod entrypoint before switching to non-root user
- add `.gitattributes` to enforce LF endings for shell scripts
- note LF requirement for `.sh` files in Quick Start documentation

## Testing
- `docker build .` *(fails: command not found)*
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4deb393148326bb88cee14db8fafc